### PR TITLE
fix: Make Photo indexes sparse to allow new user registrations (#33)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -53,7 +53,7 @@ app.use(
       sameSite: process.env.NODE_ENV !== "dev" ? "none" : "lax",
       httpOnly: true,
       signed: true,
-      partitioned: true,
+      partitioned: process.env.NODE_ENV !== "dev" ? true : false,
     },
   })
 );

--- a/src/models/photo.model.ts
+++ b/src/models/photo.model.ts
@@ -17,11 +17,13 @@ const photoSchema = new Schema<IPhoto>(
       type: Schema.Types.String,
       required: true,
       unique: true,
+      sparse: true,
     },
     url: {
       type: Schema.Types.String,
       required: true,
       unique: true,
+      sparse: true,
     },
     altText: {
       type: Schema.Types.String,


### PR DESCRIPTION
New users could not be created due to unique indexes on Photo collection. This PR makes publicId and url indexes sparse to allow null values when photoSchema is embedded in another model.