### PR TITLE
feat: Add width, height and height-width ratio to Photo model

### DIFF
--- a/src/models/photo.model.ts
+++ b/src/models/photo.model.ts
@@ -4,6 +4,10 @@ interface IPhoto {
   publicId: string;
   url: string;
   altText?: string;
+  aspectRatio?: string;
+  hwRatio: string;
+  width: number;
+  height: number;
 }
 
 type PhotoInput = {
@@ -29,6 +33,24 @@ const photoSchema = new Schema<IPhoto>(
       type: Schema.Types.String,
       required: false,
       default: "",
+    },
+    aspectRatio: {
+      type: Schema.Types.String,
+      enum: ["16/9", "4/3"],
+      required: false,
+    },
+    hwRatio: {
+      type: Schema.Types.String,
+      required: true,
+      default: "100%",
+    },
+    width: {
+      type: Schema.Types.Number,
+      required: true,
+    },
+    height: {
+      type: Schema.Types.Number,
+      required: true,
     },
   },
   {


### PR DESCRIPTION
This PR adds a photo details fetch from Cloudinary after photo upload in order to store photo dimensions, which can later be used for styling photo display in frontend.  `Photo` model is extended by adding following params: `width`, `height`, `aspectRatio` enum (currently not utilized) and `hwRatio`, which contains a relative percentage value of height to width.

This can be considered a temporary solution, since cloudinary uploader response normally contains this data, but `cloudinary-multer-storage` does not provide height and width parameters in `req.file`/`req.files`. A long term solution would require rewriting the upload middleware in order to get direct access to responses from Cloudinary.