### PR TITLE
fix: Remove invalid required /for-you endpoint params

### DIFF
--- a/src/routes/posts.route.ts
+++ b/src/routes/posts.route.ts
@@ -21,7 +21,6 @@ import {
   getAllPostsSchema,
   getCurrentUserLikeSchema,
   getFollowingPostsSchema,
-  getForYouPostsSchema,
   getPostSchema,
   likePostSchema,
   unlikePostSchema,
@@ -33,11 +32,7 @@ const postsRouter = express.Router();
 const upload = uploadMiddleware("photos");
 
 postsRouter.get("/", validateResource(getAllPostsSchema), getAllPosts);
-postsRouter.get(
-  "/for-you",
-  validateResource(getForYouPostsSchema),
-  getForYouPosts
-);
+postsRouter.get("/for-you", getForYouPosts);
 postsRouter.get(
   "/following",
   [authorize, validateResource(getFollowingPostsSchema)],

--- a/src/schema/post.schema.ts
+++ b/src/schema/post.schema.ts
@@ -9,10 +9,6 @@ export const getAllPostsSchema = z.object({
     .strict(),
 });
 
-export const getForYouPostsSchema = z.object({
-  user: userSchema.required(),
-});
-
 export const getFollowingPostsSchema = z.object({
   user: userSchema.required(),
 });


### PR DESCRIPTION
`/for-you` endpoint schema erroneously required `user` object, since controller code can handle requests from both guests and logged in users.